### PR TITLE
Add possibility for JDKs substitution in the build script...

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,8 @@ pill {
     )
 }
 
+val isTeamcityBuild = project.kotlinBuildProperties.isTeamcityBuild
+
 val configuredJdks: List<JdkId> =
     getConfiguredJdks().also {
         it.forEach { jdkId ->
@@ -107,8 +109,13 @@ extra["isSonatypeRelease"] = false
 // Work-around necessary to avoid setting null javaHome. Will be removed after support of lazy task configuration
 val jdkNotFoundConst = "JDK NOT FOUND"
 
-extra["JDK_16"] = jdkPath("1.6")
-extra["JDK_17"] = jdkPath("1.7")
+if (isTeamcityBuild) {
+    extra["JDK_16"] = jdkPath("1.6")
+    extra["JDK_17"] = jdkPath("1.7")
+} else {
+    extra["JDK_16"] = jdkPath("1.6", "1.8")
+    extra["JDK_17"] = jdkPath("1.7", "1.8")
+}
 extra["JDK_18"] = jdkPath("1.8")
 extra["JDK_9"] = jdkPath("9")
 extra["JDK_10"] = jdkPath("10")
@@ -167,7 +174,6 @@ if (!project.hasProperty("versions.kotlin-native")) {
     extra["versions.kotlin-native"] = "1.3.70-dev-13235"
 }
 
-val isTeamcityBuild = project.kotlinBuildProperties.isTeamcityBuild
 val intellijUltimateEnabled by extra(project.kotlinBuildProperties.intellijUltimateEnabled)
 val effectSystemEnabled by extra(project.getBooleanProperty("kotlin.compiler.effectSystemEnabled") ?: false)
 val newInferenceEnabled by extra(project.getBooleanProperty("kotlin.compiler.newInferenceEnabled") ?: false)
@@ -751,12 +757,17 @@ configure<IdeaModel> {
     }
 }
 
-fun jdkPath(version: String): String {
+fun jdkPathOrNull(version: String): String? {
     val jdkName = "JDK_${version.replace(".", "")}"
     val jdkMajorVersion = JdkMajorVersion.valueOf(jdkName)
-    return configuredJdks.find { it.majorVersion == jdkMajorVersion }?.homeDir?.canonicalPath ?: jdkNotFoundConst
+    return configuredJdks.find { it.majorVersion == jdkMajorVersion }?.homeDir?.canonicalPath
 }
 
+fun jdkPath(version: String, vararg replacementVersions: String): String {
+    return jdkPathOrNull(version) ?: run {
+        replacementVersions.asSequence().map { jdkPathOrNull(it) }.find { it != null }
+    } ?: jdkNotFoundConst
+}
 
 fun Project.configureJvmProject(javaHome: String, javaVersion: String) {
     val currentJavaHome = File(System.getProperty("java.home")!!).canonicalPath


### PR DESCRIPTION
configure substitutions for 1.6 and 1.7 for non-TeanCity builds